### PR TITLE
fix(vscode): Fix VSCode schema generation

### DIFF
--- a/src/configure/client/index.ts
+++ b/src/configure/client/index.ts
@@ -45,9 +45,7 @@ export interface StandardMCPConfig {
  * VS Code global configuration format
  */
 export interface VSCodeGlobalConfig {
-  mcp: {
-    servers: MCPServersConfig;
-  };
+  servers: MCPServersConfig;
   [key: string]: unknown;
 }
 

--- a/src/configure/client/vscode.ts
+++ b/src/configure/client/vscode.ts
@@ -64,14 +64,12 @@ vscodeClient.configTemplate = (
   }
 
   return {
-    mcp: {
-      servers: createMcpServersConfig(
-        instanceOrUrl,
-        apiToken,
-        options,
-        CLIENT.VSCODE,
-      ),
-    },
+    servers: createMcpServersConfig(
+      instanceOrUrl,
+      apiToken,
+      options,
+      CLIENT.VSCODE,
+    ),
   };
 };
 
@@ -129,10 +127,19 @@ vscodeClient.updateConfig = (
   const globalNewConfig = newConfig as VSCodeGlobalConfig;
   const result = { ...existingConfig } as ConfigFileContents &
     VSCodeGlobalConfig;
-  result.mcp = result.mcp || { servers: {} };
-  result.mcp.servers = updateMcpServersConfig(
-    result.mcp.servers || {},
-    globalNewConfig.mcp.servers,
+  
+  // Handle migration from old format (mcp.servers) to new format (servers)
+  let existingServers = result.servers || {};
+  if (result.mcp?.servers) {
+    // Migrate old format servers to new format
+    existingServers = { ...existingServers, ...result.mcp.servers };
+    // Remove the old mcp property
+    delete result.mcp;
+  }
+  
+  result.servers = updateMcpServersConfig(
+    existingServers,
+    globalNewConfig.servers,
   );
   return result;
 };

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1606,20 +1606,18 @@ describe('CLI', () => {
         const parsedContents = JSON.parse(configFileContents);
         expect(parsedContents).toMatchInlineSnapshot(`
           {
-            "mcp": {
-              "servers": {
-                "glean_local": {
-                  "args": [
-                    "-y",
-                    "@gleanwork/local-mcp-server",
-                  ],
-                  "command": "npx",
-                  "env": {
-                    "GLEAN_API_TOKEN": "glean_api_test",
-                    "GLEAN_INSTANCE": "test-domain",
-                  },
-                  "type": "stdio",
+            "servers": {
+              "glean_local": {
+                "args": [
+                  "-y",
+                  "@gleanwork/local-mcp-server",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
                 },
+                "type": "stdio",
               },
             },
           }
@@ -1681,24 +1679,22 @@ describe('CLI', () => {
         expect(parsedConfig).toMatchInlineSnapshot(`
           {
             "editor.fontSize": 14,
-            "mcp": {
-              "servers": {
-                "github-remote": {
-                  "authorization_token": "Bearer $MY_TOKEN",
-                  "url": "https://api.githubcopilot.com/mcp",
+            "servers": {
+              "github-remote": {
+                "authorization_token": "Bearer $MY_TOKEN",
+                "url": "https://api.githubcopilot.com/mcp",
+              },
+              "glean_local": {
+                "args": [
+                  "-y",
+                  "@gleanwork/local-mcp-server",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
                 },
-                "glean_local": {
-                  "args": [
-                    "-y",
-                    "@gleanwork/local-mcp-server",
-                  ],
-                  "command": "npx",
-                  "env": {
-                    "GLEAN_API_TOKEN": "glean_api_test",
-                    "GLEAN_INSTANCE": "test-domain",
-                  },
-                  "type": "stdio",
-                },
+                "type": "stdio",
               },
             },
             "workbench.colorTheme": "Default Dark+",

--- a/src/test/configure/vscode.test.ts
+++ b/src/test/configure/vscode.test.ts
@@ -74,20 +74,18 @@ describe('VS Code MCP Client', () => {
 
     expect(config).toMatchInlineSnapshot(`
       {
-        "mcp": {
-          "servers": {
-            "glean_local": {
-              "args": [
-                "-y",
-                "@gleanwork/local-mcp-server",
-              ],
-              "command": "npx",
-              "env": {
-                "GLEAN_API_TOKEN": "test-token",
-                "GLEAN_INSTANCE": "example-instance",
-              },
-              "type": "stdio",
+        "servers": {
+          "glean_local": {
+            "args": [
+              "-y",
+              "@gleanwork/local-mcp-server",
+            ],
+            "command": "npx",
+            "env": {
+              "GLEAN_API_TOKEN": "test-token",
+              "GLEAN_INSTANCE": "example-instance",
             },
+            "type": "stdio",
           },
         },
       }
@@ -174,20 +172,18 @@ describe('VS Code MCP Client', () => {
 
     expect(config).toMatchInlineSnapshot(`
       {
-        "mcp": {
-          "servers": {
-            "glean_local": {
-              "args": [
-                "-y",
-                "@gleanwork/local-mcp-server",
-              ],
-              "command": "npx",
-              "env": {
-                "GLEAN_API_TOKEN": "test-token",
-                "GLEAN_URL": "https://example.com/rest/api/v1",
-              },
-              "type": "stdio",
+        "servers": {
+          "glean_local": {
+            "args": [
+              "-y",
+              "@gleanwork/local-mcp-server",
+            ],
+            "command": "npx",
+            "env": {
+              "GLEAN_API_TOKEN": "test-token",
+              "GLEAN_URL": "https://example.com/rest/api/v1",
             },
+            "type": "stdio",
           },
         },
       }
@@ -220,13 +216,11 @@ describe('VS Code MCP Client', () => {
   it('should update global config correctly', () => {
     const existingConfig = { someOtherConfig: true };
     const newConfig: MCPConfig = {
-      mcp: {
-        servers: {
-          glean: {
-            command: 'npx',
-            args: ['-y', '@gleanwork/local-mcp-server'],
-            env: {},
-          },
+      servers: {
+        glean: {
+          command: 'npx',
+          args: ['-y', '@gleanwork/local-mcp-server'],
+          env: {},
         },
       },
     };
@@ -235,7 +229,7 @@ describe('VS Code MCP Client', () => {
 
     expect(updated).toMatchObject({
       someOtherConfig: true,
-      mcp: newConfig.mcp,
+      servers: newConfig.servers,
     });
   });
 
@@ -273,23 +267,23 @@ describe('VS Code MCP Client', () => {
     );
 
     expect(config).toMatchInlineSnapshot(`
-      {
-        "servers": {
-          "glean_local": {
-            "args": [
-              "-y",
-              "@gleanwork/local-mcp-server",
-            ],
-            "command": "npx",
-            "env": {
-              "GLEAN_API_TOKEN": "test-token",
-              "GLEAN_URL": "https://example.com/rest/api/v1",
+          {
+            "servers": {
+              "glean_local": {
+                "args": [
+                  "-y",
+                  "@gleanwork/local-mcp-server",
+                ],
+                "command": "npx",
+                "env": {
+                  "GLEAN_API_TOKEN": "test-token",
+                  "GLEAN_URL": "https://example.com/rest/api/v1",
+                },
+                "type": "stdio",
+              },
             },
-            "type": "stdio",
-          },
-        },
-      }
-    `);
+          }
+        `);
   });
 
   it('should generate global config when workspace option is false', () => {
@@ -302,20 +296,18 @@ describe('VS Code MCP Client', () => {
 
     expect(config).toMatchInlineSnapshot(`
       {
-        "mcp": {
-          "servers": {
-            "glean_local": {
-              "args": [
-                "-y",
-                "@gleanwork/local-mcp-server",
-              ],
-              "command": "npx",
-              "env": {
-                "GLEAN_API_TOKEN": "test-token",
-                "GLEAN_INSTANCE": "example-instance",
-              },
-              "type": "stdio",
+        "servers": {
+          "glean_local": {
+            "args": [
+              "-y",
+              "@gleanwork/local-mcp-server",
+            ],
+            "command": "npx",
+            "env": {
+              "GLEAN_API_TOKEN": "test-token",
+              "GLEAN_INSTANCE": "example-instance",
             },
+            "type": "stdio",
           },
         },
       }


### PR DESCRIPTION
Remove incorrect `mcp` wrapper from VS Code global configuration to match the mcp-config-schema package and VS Code's official documentation format.

