### PR TITLE
refactor: Remove `includeWrapper: false` (rely on `mcp-config-schema`)

### DIFF
--- a/src/configure/client/goose.ts
+++ b/src/configure/client/goose.ts
@@ -34,7 +34,6 @@ gooseClient.configTemplate = (
           agents: options?.agents,
         })
       : undefined,
-    includeWrapper: false,
   });
 
   // Parse the YAML to pin mcp-remote version if needed

--- a/src/configure/client/index.ts
+++ b/src/configure/client/index.ts
@@ -42,17 +42,9 @@ export interface StandardMCPConfig {
 }
 
 /**
- * VS Code global configuration format
+ * VS Code configuration format
  */
-export interface VSCodeGlobalConfig {
-  servers: MCPServersConfig;
-  [key: string]: unknown;
-}
-
-/**
- * VS Code workspace configuration format
- */
-export interface VSCodeWorkspaceConfig {
+export interface VSCodeConfig {
   servers: MCPServersConfig;
   [key: string]: unknown;
 }
@@ -62,8 +54,7 @@ export interface VSCodeWorkspaceConfig {
  */
 export type MCPConfig =
   | StandardMCPConfig
-  | VSCodeGlobalConfig
-  | VSCodeWorkspaceConfig
+  | VSCodeConfig
   | Record<string, any>; // Goose and other YAML-based configs
 
 /**
@@ -145,7 +136,6 @@ export function createMcpServersConfig(
           agents: options?.agents,
         })
       : undefined,
-    includeWrapper: false,
   });
 
   let parsed: any;

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1434,23 +1434,25 @@ describe('CLI', () => {
         const parsedConfig = yaml.parse(configFileContents);
         expect(parsedConfig).toMatchInlineSnapshot(`
           {
-            "glean_local": {
-              "args": [
-                "-y",
-                "@gleanwork/local-mcp-server",
-              ],
-              "bundled": null,
-              "cmd": "npx",
-              "description": null,
-              "enabled": true,
-              "env_keys": [],
-              "envs": {
-                "GLEAN_API_TOKEN": "glean_api_test",
-                "GLEAN_INSTANCE": "test-domain",
+            "extensions": {
+              "glean_local": {
+                "args": [
+                  "-y",
+                  "@gleanwork/local-mcp-server",
+                ],
+                "bundled": null,
+                "cmd": "npx",
+                "description": null,
+                "enabled": true,
+                "env_keys": [],
+                "envs": {
+                  "GLEAN_API_TOKEN": "glean_api_test",
+                  "GLEAN_INSTANCE": "test-domain",
+                },
+                "name": "glean_local",
+                "timeout": 300,
+                "type": "stdio",
               },
-              "name": "glean_local",
-              "timeout": 300,
-              "type": "stdio",
             },
           }
         `);
@@ -1502,24 +1504,6 @@ describe('CLI', () => {
         const parsedConfig = yaml.parse(configFileContents);
         expect(parsedConfig).toMatchInlineSnapshot(`
           {
-            "glean_local": {
-              "args": [
-                "-y",
-                "@gleanwork/local-mcp-server",
-              ],
-              "bundled": null,
-              "cmd": "npx",
-              "description": null,
-              "enabled": true,
-              "env_keys": [],
-              "envs": {
-                "GLEAN_API_TOKEN": "glean_api_test",
-                "GLEAN_INSTANCE": "test-domain",
-              },
-              "name": "glean_local",
-              "timeout": 300,
-              "type": "stdio",
-            },
             "some-other-config": {
               "options": {
                 "enabled": true,


### PR DESCRIPTION
Replace manual wrapper management with schema-driven configuration generation. Remove `includeWrapper: false` to let the mcp-config-schema package handle the correct format for each client automatically.

This eliminates manual wrapper logic scattered throughout the codebase and ensures configurations always match the authoritative schema definitions.

Before: Manual format management with `{ servers: createMcpServersConfig(...) }`
After: Schema-driven with `builder.buildConfiguration({ ... })`