### PR TITLE
Diagnose and fix test failure in PR 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@gleanwork/mcp-config-schema": "^0.11.0",
         "@gleanwork/mcp-server-utils": "^0.7.18",
         "dotenv": "^17.2.1",
-        "mcp-remote": "^0.1.18",
+        "mcp-remote": "^0.1.29",
         "meow": "^13.2.0",
         "tldts": "^7.0.10",
         "yaml": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@gleanwork/mcp-config-schema": "^0.11.0",
     "@gleanwork/mcp-server-utils": "^0.7.18",
     "dotenv": "^17.2.1",
-    "mcp-remote": "^0.1.18",
+    "mcp-remote": "^0.1.29",
     "meow": "^13.2.0",
     "tldts": "^7.0.10",
     "yaml": "^2.8.0"

--- a/src/test/cli.test.ts
+++ b/src/test/cli.test.ts
@@ -1257,7 +1257,7 @@ describe('CLI', () => {
                 "command": "npx",
                 "args": [
                   "-y",
-                  "mcp-remote@0.1.18",
+                  "mcp-remote@0.1.29",
                   "https://my-be.glean.com/mcp/default"
                 ]
               }
@@ -1693,7 +1693,7 @@ describe('CLI', () => {
                 "command": "npx",
                 "args": [
                   "-y",
-                  "mcp-remote@0.1.18",
+                  "mcp-remote@0.1.29",
                   "https://new-be.glean.com/mcp/default",
                   "--header",
                   "Authorization: Bearer auth-token"


### PR DESCRIPTION
## Description

This PR fixes failing snapshot tests caused by an update to the `mcp-remote` dependency. The snapshot expectations in `src/test/cli.test.ts` were updated to reflect the new `mcp-remote` version.

## Related Issue

Fixes #

## Motivation and Context

The `mcp-remote` dependency was updated from `0.1.18` to `0.1.29`. This change caused existing snapshot tests to fail because they contained hardcoded version strings (`"mcp-remote@0.1.18"`). This PR updates those snapshot expectations to align with the new dependency version, ensuring tests pass correctly.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Build/CI pipeline changes
- [ ] Other (please describe):

## How Has This Been Tested?

- [x] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Other (please describe):
  All existing snapshot tests were run and now pass.

## Checklist

- [x] My code follows the code style of this project
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes (existing tests were updated)
- [ ] I have checked for potential breaking changes and addressed them

## Screenshots (if appropriate)

## Additional Notes

The `mcp-remote` upgrade from 0.1.18 to 0.1.29 did not introduce any functional breaking changes; the test failures were solely due to the hardcoded version strings in the snapshot output.

---
<a href="https://cursor.com/background-agent?bcId=bc-176eed02-20c1-428f-994b-6333f2d690d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-176eed02-20c1-428f-994b-6333f2d690d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

