### PR TITLE
chore: Update dependabot schedule & group dev-deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,12 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     cooldown:
       default-days: 5
       semver-major-days: 30
       semver-minor-days: 7
       semver-patch-days: 3
+    groups:
+      dev-dependencies:
+        dependency-type: "development"


### PR DESCRIPTION
Change Dependabot to only run monthly, and to group all dev-dependency bumps together.