### PR TITLE
Inline mcp-server-utils utilities; drop the dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@gleanwork/mcp-config-glean": "^5.0.0",
-        "@gleanwork/mcp-server-utils": "^0.9.1",
         "commander": "^14.0.2",
         "dotenv": "^17.2.1",
         "mcp-remote": "^0.1.29",
+        "open": "^11.0.0",
         "tldts": "^7.0.10",
         "yaml": "^2.8.0"
       },
@@ -38,7 +38,6 @@
         "jiti": "^2.5.1",
         "msw": "^2.10.5",
         "npm-run-all": "^4.1.5",
-        "open": "^11.0.0",
         "prettier": "^3.6.2",
         "release-it": "^19.0.4",
         "rimraf": "^6.0.1",
@@ -720,53 +719,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@gleanwork/connect-mcp-server": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@gleanwork/connect-mcp-server/-/connect-mcp-server-0.2.4.tgz",
-      "integrity": "sha512-9EswjKncBNcAZtWzBJi3oBHVMR5d/75iOHJNFkjvR0Imqrd2coVp/o5LSckyKHYwm/8TeybDbr2KkLISpfNRag==",
-      "dependencies": {
-        "express": "^4.21.2",
-        "open": "^10.1.0",
-        "strict-url-sanitise": "^0.0.1"
-      },
-      "bin": {
-        "connect-mcp-server": "dist/proxy.js",
-        "connect-mcp-server-client": "dist/client.js"
-      }
-    },
-    "node_modules/@gleanwork/connect-mcp-server/node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@gleanwork/connect-mcp-server/node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@gleanwork/mcp-config-glean": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@gleanwork/mcp-config-glean/-/mcp-config-glean-5.0.0.tgz",
@@ -795,56 +747,6 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@gleanwork/mcp-server-utils": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@gleanwork/mcp-server-utils/-/mcp-server-utils-0.9.1.tgz",
-      "integrity": "sha512-mRExkYjku9QFFjGGSI/U/NLJAnBaai+pyDpYdFpMqqi/91jsrSfhcrUtyKxES0rjE95GLIjpSKLi9YTSPio+Ig==",
-      "license": "MIT",
-      "dependencies": {
-        "@gleanwork/connect-mcp-server": "^0.2.4",
-        "dotenv": "^17.2.3",
-        "fs-extra": "^11.3.2",
-        "open": "^10.2.0",
-        "tldts": "^7.0.17",
-        "zod": "^4.1.12"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@gleanwork/mcp-server-utils/node_modules/open": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
-      "license": "MIT",
-      "dependencies": {
-        "default-browser": "^5.2.1",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "wsl-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@gleanwork/mcp-server-utils/node_modules/wsl-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.1.0.tgz",
-      "integrity": "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-wsl": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@gwhitney/detect-indent": {
@@ -7417,6 +7319,7 @@
       "version": "11.3.3",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
       "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -7823,6 +7726,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
@@ -8457,7 +8361,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
       "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -8928,6 +8831,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -10847,7 +10751,6 @@
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
       "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.4.0",
@@ -11493,7 +11396,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
       "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -13734,6 +13636,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -14482,7 +14385,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
       "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-wsl": "^3.1.0",
@@ -14648,6 +14550,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.5.tgz",
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
   },
   "dependencies": {
     "@gleanwork/mcp-config-glean": "^5.0.0",
-    "@gleanwork/mcp-server-utils": "^0.9.1",
     "commander": "^14.0.2",
     "dotenv": "^17.2.1",
     "mcp-remote": "^0.1.29",
+    "open": "^11.0.0",
     "tldts": "^7.0.10",
     "yaml": "^2.8.0"
   },
@@ -76,7 +76,6 @@
     "jiti": "^2.5.1",
     "msw": "^2.10.5",
     "npm-run-all": "^4.1.5",
-    "open": "^11.0.0",
     "prettier": "^3.6.2",
     "release-it": "^19.0.4",
     "rimraf": "^6.0.1",

--- a/src/common/launch-warning-checker.ts
+++ b/src/common/launch-warning-checker.ts
@@ -1,0 +1,155 @@
+import open from 'open';
+import { trace } from './logger.js';
+
+/**
+ * Result of checking for launch warnings
+ */
+export interface LaunchWarningResult {
+  /** Whether a warning URL was found and opened */
+  opened: boolean;
+  /** The URL that was checked */
+  url: string;
+  /** Any error that occurred during the process */
+  error?: Error;
+}
+
+const BASE_URL = 'https://gleanwork.github.io/mcp-server/warnings/launch/';
+
+const TIMEOUT_MS = 1000;
+
+/**
+ * Determines the version string to use in the URL based on semantic versioning rules
+ * - If major version > 0: Use only the major version (e.g., "1.2.3" → "v1")
+ * - If major version = 0: Use major.minor (e.g., "0.6.3" → "v0.6")
+ */
+export function getVersionString(version: string): string {
+  const versionMatch = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!versionMatch) {
+    throw new Error(`Invalid version format: ${version}`);
+  }
+
+  const [, major, minor] = versionMatch;
+  const majorNum = parseInt(major, 10);
+
+  if (majorNum > 0) {
+    return `v${major}`;
+  } else {
+    return `v${major}.${minor}`;
+  }
+}
+
+/**
+ * Builds the launch warning URL based on the version
+ */
+export function buildLaunchWarningUrl(version: string): string {
+  const versionString = getVersionString(version);
+  return `${BASE_URL}${versionString}.md`;
+}
+
+/**
+ * Checks if a URL exists by making a HEAD request
+ * Returns true if the URL exists (status 200-299), false otherwise
+ */
+export async function checkUrlExists(url: string): Promise<boolean> {
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+    const response = await fetch(url, {
+      method: 'HEAD',
+      signal: controller.signal,
+      redirect: 'follow',
+    });
+
+    clearTimeout(timeoutId);
+
+    return response.status >= 200 && response.status < 300;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Opens a URL in the default browser
+ */
+export async function openInBrowser(url: string): Promise<void> {
+  await open(url);
+}
+
+/**
+  Checks for known version-specific launch warnings and automatically opens
+  them in the browser.
+
+  This function is the main entry point for the launch warning system. It
+  takes a package version, constructs a URL to check for known issues
+  documentation, verifies the URL exists remotely, and if found, opens the
+  warning page in the user's default browser.
+
+  @param version - The semantic version string of the package (e.g., "1.2.3", "0.6.1")
+
+  @returns Promise resolving to LaunchWarningResult containing:
+    - `opened`: true if a warning was found and browser was opened, false otherwise
+    - `url`: the warning URL that was constructed and checked
+    - `error`: any error that occurred during URL building, network checking, or browser opening
+
+  @example
+  ```typescript
+  const result = await checkAndOpenLaunchWarning("1.2.3");
+  if (result.opened) {
+    console.log(`Opened warning page: ${result.url}`);
+  } else if (result.error) {
+    console.error(`Failed to check warnings: ${result.error.message}`);
+  } else {
+    console.log(`No warnings found for version 1.2.3`);
+  }
+  ```
+
+  @throws Never throws directly - all errors are caught and returned in the result object
+ */
+export async function checkAndOpenLaunchWarning(
+  version: string,
+): Promise<LaunchWarningResult> {
+  let url: string;
+
+  try {
+    url = buildLaunchWarningUrl(version);
+  } catch (error) {
+    trace('launch-warning-checker', 'Error building URL:', error);
+    return {
+      opened: false,
+      url: '',
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+
+  let versionWarningExists: boolean | null = null;
+
+  try {
+    versionWarningExists = await checkUrlExists(url);
+  } catch (error) {
+    trace('launch-warning-checker', 'Error checking remote URL', url, error);
+
+    return {
+      opened: false,
+      url,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+
+  try {
+    if (versionWarningExists) {
+      await openInBrowser(url);
+
+      return { opened: true, url };
+    }
+
+    return { opened: false, url };
+  } catch (error) {
+    trace('launch-warning-checker', 'Error launching the browser', error);
+    return {
+      opened: false,
+      url,
+      error: error instanceof Error ? error : new Error(String(error)),
+    };
+  }
+}

--- a/src/common/logger.ts
+++ b/src/common/logger.ts
@@ -1,0 +1,187 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// ponytail: inlined from @gleanwork/mcp-server-utils — only the log-file path
+// helpers the Logger needs (formerly the xdg module). Pure node built-ins.
+function getStateDir(name: string) {
+  const platform = os.platform();
+  const homeDir = os.homedir();
+
+  // Check for XDG_STATE_HOME first
+  const xdgStateHome = process.env.XDG_STATE_HOME;
+  if (xdgStateHome) {
+    return path.join(xdgStateHome, name);
+  }
+
+  // Platform-specific defaults
+  if (platform === 'win32') {
+    // Windows: %LOCALAPPDATA%\state\{name}
+    const localAppData =
+      process.env.LOCALAPPDATA || path.join(homeDir, 'AppData', 'Local');
+    return path.join(localAppData, 'state', name);
+  }
+
+  // Unix-like (Linux, macOS, etc): ~/.local/state/{name}
+  return path.join(homeDir, '.local', 'state', name);
+}
+
+function ensureFileExistsWithLimitedPermissions(filePath: string) {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+  if (!fs.existsSync(filePath)) {
+    fs.writeFileSync(filePath, '', { encoding: 'utf8' });
+  }
+
+  fs.chmodSync(filePath, 0o600);
+}
+
+export enum LogLevel {
+  TRACE = 0,
+  DEBUG = 1,
+  INFO = 2,
+  WARN = 3,
+  ERROR = 4,
+}
+
+/**
+ * A simple logger that exposes functions for standard log levels (`trace,
+ * `debug`, &c.) for a singleton logger.
+ *
+ * Logs are written to `$HOME/.local/state/glean/mcp.log` by default (or the
+ * XDG equivalent for windows, or if XDG env vars are set).
+ *
+ * Logs are intended to be provided by users to help with troubleshooting.
+ */
+export class Logger {
+  private static instance?: Logger;
+  private logFilePath: string;
+  private logLevel: LogLevel;
+
+  constructor(appName = 'glean') {
+    const logDir = getStateDir(appName);
+
+    // Ensure log directory exists
+    if (!fs.existsSync(logDir)) {
+      fs.mkdirSync(logDir, { recursive: true });
+    }
+
+    this.logFilePath = path.join(logDir, 'mcp.log');
+    ensureFileExistsWithLimitedPermissions(this.logFilePath);
+    this.logLevel = LogLevel.TRACE; // Default to most verbose logging
+  }
+
+  public static getInstance(): Logger {
+    if (!Logger.instance) {
+      Logger.instance = new Logger();
+    }
+    return Logger.instance;
+  }
+
+  public static reset() {
+    Logger.instance = undefined;
+  }
+
+  public setLogLevel(level: LogLevel): void {
+    this.logLevel = level;
+  }
+
+  private log(level: LogLevel, ...args: any[]): void {
+    if (level < this.logLevel) return;
+
+    const timestamp = new Date().toISOString();
+    const levelName = LogLevel[level];
+
+    let message = '';
+    const dataObjects: Record<string, unknown>[] = [];
+
+    // Helper to format errors with causes
+    function formatErrorWithCauses(err: Error, indent = 0): string {
+      const pad = '  '.repeat(indent);
+      let out = `${pad}[${err.name}: ${err.message}]`;
+      if (err.stack) {
+        // Only include stack for the top-level error
+        if (indent === 0) {
+          out += `\n${pad}${err.stack.replace(/\n/g, `\n${pad}`)}`;
+        }
+      }
+      // Handle error cause (ES2022 standard, but may be polyfilled)
+      const cause = (err as any).cause;
+      if (cause instanceof Error) {
+        out += `\n${pad}Caused by: ` + formatErrorWithCauses(cause, indent + 1);
+      } else if (cause !== undefined) {
+        out += `\n${pad}Caused by: ${JSON.stringify(cause)}`;
+      }
+      return out;
+    }
+
+    // Process each argument
+    args.forEach((arg) => {
+      if (typeof arg === 'string') {
+        message += (message ? ' ' : '') + arg;
+      } else if (arg instanceof Error) {
+        message += (message ? ' ' : '') + formatErrorWithCauses(arg);
+      } else if (arg !== null && typeof arg === 'object') {
+        dataObjects.push(arg);
+      } else if (arg !== undefined) {
+        // Convert primitives to string
+        message += (message ? ' ' : '') + String(arg);
+      }
+    });
+
+    let logMessage = `[${timestamp}] [${levelName}] ${message}`;
+
+    // Add data objects if any
+    if (dataObjects.length > 0) {
+      dataObjects.forEach((data) => {
+        logMessage += ` ${JSON.stringify(data)}`;
+      });
+    }
+
+    logMessage += '\n';
+
+    // Append to log file
+    fs.appendFileSync(this.logFilePath, logMessage);
+  }
+
+  public trace(...args: any[]): void {
+    this.log(LogLevel.TRACE, ...args);
+  }
+
+  public debug(...args: any[]): void {
+    this.log(LogLevel.DEBUG, ...args);
+  }
+
+  public info(...args: any[]): void {
+    this.log(LogLevel.INFO, ...args);
+  }
+
+  public warn(...args: any[]): void {
+    this.log(LogLevel.WARN, ...args);
+  }
+
+  public error(...args: any[]): void {
+    this.log(LogLevel.ERROR, ...args);
+  }
+}
+
+// Exported functions
+export function trace(...args: any[]): void {
+  Logger.getInstance().trace(...args);
+}
+
+export function debug(...args: any[]): void {
+  Logger.getInstance().debug(...args);
+}
+
+export function info(...args: any[]): void {
+  Logger.getInstance().info(...args);
+}
+
+export function warn(...args: any[]): void {
+  Logger.getInstance().warn(...args);
+}
+
+export function error(...args: any[]): void {
+  Logger.getInstance().error(...args);
+}

--- a/src/common/preflight.ts
+++ b/src/common/preflight.ts
@@ -1,0 +1,85 @@
+import { trace, error } from './logger.js';
+
+/**
+ * Validates that the given instance name or server URL is valid by checking its liveness endpoint.
+ * When GLEAN_SERVER_URL is set, validates using that URL directly.
+ * Otherwise, makes a fetch request to https://{instance}-be.glean.com/liveness_check
+ *
+ * @param instance - The instance name to validate
+ * @returns A Promise that resolves to true if the instance is valid
+ */
+export async function validateInstance(instance: string): Promise<boolean> {
+  // If GLEAN_SERVER_URL is set, skip instance name validation and validate the server URL directly
+  const serverUrl = process.env.GLEAN_SERVER_URL;
+  if (serverUrl) {
+    return validateServerUrl(serverUrl);
+  }
+
+  if (!instance) {
+    trace('No instance provided for validation');
+    return false;
+  }
+
+  try {
+    const url = `https://${instance}-be.glean.com/liveness_check`;
+    trace(`Checking instance validity with: ${url}`);
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    // We only care that the request succeeds, not about the response content
+    if (!response.ok) {
+      error(
+        `Instance validation failed for ${instance}: ${response.status} ${response.statusText}`,
+      );
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    const cause = err instanceof Error ? err : new Error(String(err));
+
+    error(`Instance validation failed: ${cause.message}`);
+    return false;
+  }
+}
+
+/**
+ * Validates a server URL by checking its liveness endpoint.
+ *
+ * @param serverUrl - The full server URL to validate
+ * @returns A Promise that resolves to true if the server is reachable
+ */
+async function validateServerUrl(serverUrl: string): Promise<boolean> {
+  try {
+    const normalizedUrl = /^https?:\/\//i.test(serverUrl)
+      ? serverUrl
+      : `https://${serverUrl}`;
+    const url = `${normalizedUrl.replace(/\/+$/, '')}/liveness_check`;
+    trace(`Checking server URL validity with: ${url}`);
+
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      error(
+        `Server URL validation failed for ${serverUrl}: ${response.status} ${response.statusText}`,
+      );
+      return false;
+    }
+
+    return true;
+  } catch (err) {
+    const cause = err instanceof Error ? err : new Error(String(err));
+    error(`Server URL validation failed: ${cause.message}`);
+    return false;
+  }
+}

--- a/src/configure/index.ts
+++ b/src/configure/index.ts
@@ -18,8 +18,8 @@ import {
   MCPConfig,
   ConfigFileContents,
 } from './client/index.js';
-import { trace, error } from '@gleanwork/mcp-server-utils/logger';
-import { validateInstance } from '@gleanwork/mcp-server-utils/util';
+import { trace, error } from '../common/logger.js';
+import { validateInstance } from '../common/preflight.js';
 import { VERSION } from '../common/version.js';
 
 export type { MCPConfig, ConfigFileContents } from './client/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,9 @@ import {
 } from './configure/index.js';
 import { availableClients } from './configure/client/index.js';
 import { initializeProject } from './init/index.js';
-import { Logger, trace, LogLevel } from '@gleanwork/mcp-server-utils/logger';
+import { Logger, trace, LogLevel } from './common/logger.js';
 import { VERSION } from './common/version.js';
-import { checkAndOpenLaunchWarning } from '@gleanwork/mcp-server-utils/util';
+import { checkAndOpenLaunchWarning } from './common/launch-warning-checker.js';
 import { createGleanRegistry } from '@gleanwork/mcp-config-glean';
 
 /**

--- a/src/test/configure.test.ts
+++ b/src/test/configure.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { configure, ConfigureOptions } from '../configure/index.js';
-import { validateInstance } from '@gleanwork/mcp-server-utils/util';
+import { validateInstance } from '../common/preflight.js';
 import os from 'os';
 import path from 'path';
 import fs from 'fs';
-import { Logger } from '@gleanwork/mcp-server-utils/logger';
+import { Logger } from '../common/logger.js';
 
-vi.mock('@gleanwork/mcp-server-utils/util', () => ({
+vi.mock('../common/preflight.js', () => ({
   validateInstance: vi.fn(),
 }));
 


### PR DESCRIPTION
## What

Removes the `@gleanwork/mcp-server-utils` dependency from `configure-mcp-server` by inlining the small surface it actually used.

## Why

The `@gleanwork/mcp-server` monorepo that publishes `mcp-server-utils` is being wound down in favor of the remote MCP server. Dropping the dependency removes that coupling and shrinks configure's external dependency / vulnerability-scanning surface.

## Changes

- New `src/common/logger.ts`, `src/common/launch-warning-checker.ts`, `src/common/preflight.ts`, copied from `mcp-server-utils`. The logger's log-file path helper is folded directly into `logger.ts`, so no `xdg` module is needed.
- Repointed imports in `src/index.ts`, `src/configure/index.ts`, and `src/test/configure.test.ts` (including the `vi.mock` target).
- `package.json`: removed `@gleanwork/mcp-server-utils`; promoted `open` to a runtime dependency (the inlined launch-warning code imports it).
- Regenerated `package-lock.json`.

## Verification

- `npm test` → 158/158 passing
- `eslint` and `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
